### PR TITLE
Various editorial updates

### DIFF
--- a/draft-looker-oauth-attested-key-based-client-authentication.md
+++ b/draft-looker-oauth-attested-key-based-client-authentication.md
@@ -26,6 +26,7 @@ normative:
   RFC6755: RFC6755
   RFC7591: RFC7591
   RFC7519: RFC7519
+  RFC8414: RFC8414
   DPOP:
     title: "OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP)"
     author:
@@ -203,19 +204,21 @@ The following rules apply to validating the client key attestation PoP JWT. Appl
 
 2. The JWT MUST contain an "exp" (expiration time) claim that limits the time window during which the JWT can be used.  The authorization server MUST reject any JWT with an expiration time that has passed, subject to allowable clock skew between systems.  Note that the authorization server may reject JWTs with an "exp" claim value that is unreasonably far in the future.
 
-3. 5. The JWT MUST contain a "jti" (JWT ID) claim that provides a unique identifier for the token.  The authorization server MAY ensure that JWTs are not replayed by maintaining the set of used "jti" values for the length of time for which the JWT would be considered valid based on the applicable "exp" instant.
+3. The JWT MUST contain a "jti" (JWT ID) claim that provides a unique identifier for the token.  The authorization server MAY ensure that JWTs are not replayed by maintaining the set of used "jti" values for the length of time for which the JWT would be considered valid based on the applicable "exp" instant.
 
-4. The JWT MAY contain an "nbf" (not before) claim that identifies the time before which the token MUST NOT be accepted for processing.
+4. The JWT MUST contain an "aud" (audience) claim containing a value that identifies the authorization server as an intended audience. The {{RFC8414}} issuer identifier URL of the authorization server MUST be used as a value for an "aud" element to identify the authorization server as the intended audience of the JWT.
 
-5. The JWT MAY contain an "iat" (issued at) claim that identifies the time at which the JWT was issued.  Note that the authorization server may reject JWTs with an "iat" claim value that is unreasonably far in the past.
+5. The JWT MAY contain an "nbf" (not before) claim that identifies the time before which the token MUST NOT be accepted for processing.
 
-6. The JWT MAY contain other claims.
+6. The JWT MAY contain an "iat" (issued at) claim that identifies the time at which the JWT was issued.  Note that the authorization server may reject JWTs with an "iat" claim value that is unreasonably far in the past.
 
-7. The JWT MUST be digitally signed using an asymmetric cryptographic algorithm. The authorization server MUST reject the JWT if it is using a Message Authentication Code (MAC) based algorithm. The authorization server MUST reject JWTs with an invalid signature.
+7. The JWT MAY contain other claims.
 
-8. The public key used to verify the JWT MUST be the key located in the "cnf" claim of the corresponding client key attestation JWT.
+8. The JWT MUST be digitally signed using an asymmetric cryptographic algorithm. The authorization server MUST reject the JWT if it is using a Message Authentication Code (MAC) based algorithm. The authorization server MUST reject JWTs with an invalid signature.
 
-9. The authorization server MUST reject a JWT that is not valid in all other respects per "JSON Web Token (JWT)" {{RFC7519}}.
+9. The public key used to verify the JWT MUST be the key located in the "cnf" claim of the corresponding client key attestation JWT.
+
+10. The authorization server MUST reject a JWT that is not valid in all other respects per "JSON Web Token (JWT)" {{RFC7519}}.
 
 The following example is the decoded header and payload of a JWT meeting the processing rules as defined above.
 


### PR DESCRIPTION
The following changes are encapsulated in this PR:

- Update references from RFC7523 to RFC7521.
- Added a recommendation around order of validation for the two JWTs in the client_assertion parameter.
- Removed the note from the exp and iat claims for the client key Attestation JWT that imply this cannot be re-used across multiple requests.
- Removed the ability to use MAC based algorithms when producing the client key Attestation JWT.
- Updated the requirements around the presence of the JTI claim for the client key attestation PoP to be a MUST inline with DPoP PoPs for reliable basic replay attack detection mechanism.
- Added references to the JWT RFC.
- Added an implementation consideration that highlights a client instance can re-use a client key attestation JWT in multiple AS interactions/requests.
- Added aud as a required claim in the client attestation pop JWT.
- Add IANA registration request for the new client assertion type and token endpoint authentication method.